### PR TITLE
Replacing Cache.lock with sync.RWMutex (instead of sync.Mutex)

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -45,8 +45,9 @@ type Cache interface {
 
 // Stats - counters
 type Stats struct {
-	Count int
-	Size  int
-	Hit   int
-	Miss  int
+	Count          int
+	Size           int
+	Hit            int
+	Miss           int
+	PromotionFails int
 }

--- a/cache/cache_data.go
+++ b/cache/cache_data.go
@@ -17,7 +17,7 @@ type cache struct {
 	// When the item is accessed, it's moved to the end of the list.
 	usage listItem
 
-	lock sync.Mutex
+	lock sync.RWMutex
 	size uint // current size in bytes (keys+values)
 
 	conf Config
@@ -116,13 +116,13 @@ func (c *cache) Set(key []byte, val []byte) bool {
 
 // Get value
 func (c *cache) Get(key []byte) []byte {
-	c.lock.Lock()
+	c.lock.RLock()
 	val, ok := c.items[string(key)]
 	if ok && c.conf.EnableLRU {
 		listUnlink(&val.used)
 		listAppend(&val.used, listLast(&c.usage))
 	}
-	c.lock.Unlock()
+	c.lock.RUnlock()
 	if !ok {
 		atomic.AddInt32(&c.miss, 1)
 		return nil

--- a/cache/cache_data.go
+++ b/cache/cache_data.go
@@ -15,16 +15,20 @@ type cache struct {
 	// Note: slows down Get() due to an additional work with pointers
 	// Example: [ (sentinel) <-> item1 <-> item2 <-> (sentinel) ]
 	// When the item is accessed, it's moved to the end of the list.
-	usage listItem
+	usage     listItem
+	usageLock sync.Mutex
 
-	lock sync.RWMutex
-	size uint // current size in bytes (keys+values)
+	lock          sync.RWMutex
+	size          uint       // current size in bytes (keys+values)
+	promotions    chan *item // channel to buffer item promotions
+	promoterClose chan interface{}
 
 	conf Config
 
 	// stats:
-	miss int32 // number of misses
-	hit  int32 // number of hits
+	miss           int32 // number of misses
+	hit            int32 // number of hits
+	promotionFails int32 // number of failed promotions due to congestion
 }
 
 type item struct {
@@ -37,8 +41,9 @@ const maxUint = (1 << (unsafe.Sizeof(uint(0)) * 8)) - 1
 
 func newCache(conf Config) *cache {
 	c := cache{}
-	c.items = make(map[string]*item)
-	listInit(&c.usage)
+	c.Clear()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.conf = conf
 	if c.conf.MaxSize == 0 {
 		c.conf.MaxSize = maxUint
@@ -58,11 +63,16 @@ func newCache(conf Config) *cache {
 func (c *cache) Clear() {
 	c.lock.Lock()
 	c.items = make(map[string]*item)
-	listInit(&c.usage)
 	c.size = 0
 	c.lock.Unlock()
+
+	c.usageLock.Lock()
+	listInit(&c.usage)
+	c.usageLock.Unlock()
+
 	atomic.StoreInt32(&c.hit, 0)
 	atomic.StoreInt32(&c.miss, 0)
+	atomic.StoreInt32(&c.promotionFails, 0)
 }
 
 // Set value
@@ -77,10 +87,12 @@ func (c *cache) Set(key []byte, val []byte) bool {
 	it.value = val
 
 	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.usageLock.Lock()
+	defer c.usageLock.Unlock()
 
 	if !c.conf.EnableLRU &&
 		(c.size+addSize > c.conf.MaxSize || uint(len(c.items)) == c.conf.MaxCount) {
-		c.lock.Unlock()
 		return false // cache is full
 	}
 
@@ -92,9 +104,7 @@ func (c *cache) Set(key []byte, val []byte) bool {
 		delete(c.items, string(it.key))
 
 		if c.conf.OnDelete != nil {
-			c.lock.Unlock()
 			c.conf.OnDelete(it.key, it.value)
-			c.lock.Lock()
 		}
 	}
 
@@ -109,20 +119,21 @@ func (c *cache) Set(key []byte, val []byte) bool {
 	}
 	c.items[string(key)] = &it
 	c.size += addSize
-	c.lock.Unlock()
 
 	return exists
 }
 
 // Get value
 func (c *cache) Get(key []byte) []byte {
+
 	c.lock.RLock()
 	val, ok := c.items[string(key)]
-	if ok && c.conf.EnableLRU {
-		listUnlink(&val.used)
-		listAppend(&val.used, listLast(&c.usage))
-	}
 	c.lock.RUnlock()
+
+	if ok && c.conf.EnableLRU {
+		c.promote(val)
+	}
+
 	if !ok {
 		atomic.AddInt32(&c.miss, 1)
 		return nil
@@ -152,5 +163,37 @@ func (c *cache) Stats() Stats {
 	s.Size = int(c.size)
 	s.Hit = int(atomic.LoadInt32(&c.hit))
 	s.Miss = int(atomic.LoadInt32(&c.miss))
+	s.PromotionFails = int(atomic.LoadInt32(&c.promotionFails))
 	return s
+}
+
+// promote - promotes LRU values
+func (c *cache) promote(item *item) {
+	select {
+	case c.promotions <- item:
+	default:
+		atomic.AddInt32(&c.promotionFails, 1)
+	}
+}
+
+// promoter - executes promotions on usage
+func (c *cache) promoter() {
+	for {
+		select {
+		case item := <-c.promotions:
+			c.lock.RLock()
+			_, ok := c.items[string(item.key)]
+			if ok {
+				c.usageLock.Lock()
+				listUnlink(&item.used)
+				listAppend(&item.used, listLast(&c.usage))
+				c.usageLock.Unlock()
+			} else {
+				atomic.AddInt32(&c.promotionFails, 1)
+			}
+			c.lock.RUnlock() // unlock last to prevent modification by Set()
+		case <-c.promoterClose:
+			return
+		}
+	}
 }


### PR DESCRIPTION
- replaced type of Cache.lock
- changed Get() calls from lock.Lock() to lock.RLock() (and lock.RUnlock() respectively)
- allows for multiple concurrent readers
- [only locks for single process/thread if a write call happens](https://golang.org/pkg/sync/#RWMutex)

This should improve performance in excessive concurrent use cases