### PR TITLE
osuitl: Add Plan 9 support

### DIFF
--- a/osutil/fs_plan9.go
+++ b/osutil/fs_plan9.go
@@ -1,0 +1,13 @@
+//go:build plan9
+
+package osutil
+
+import (
+	"io/fs"
+	"os"
+)
+
+// rootDirFS returns a filesystem rooted at the system's root directory.
+func rootDirFS() (fsys fs.FS) {
+	return os.DirFS("/")
+}

--- a/osutil/signal_plan9.go
+++ b/osutil/signal_plan9.go
@@ -1,0 +1,38 @@
+//go:build plan9
+
+package osutil
+
+import (
+	"os"
+	"syscall"
+)
+
+const sigquit = syscall.Note("quit")
+
+// isReconfigureSignal returns true if sig is a Plan 9 reconfigure signal.
+func isReconfigureSignal(sig os.Signal) (ok bool) {
+	return sig == syscall.SIGHUP
+}
+
+// isShutdownSignal returns true if sig is a Plan 9 shutdown signal.
+func isShutdownSignal(sig os.Signal) (ok bool) {
+	switch sig {
+	case
+		syscall.SIGINT,
+		sigquit:
+		return true
+	default:
+		return false
+	}
+}
+
+// notifyReconfigureSignal notifies c on receiving Plan 9 reconfigure signals
+// using n.
+func notifyReconfigureSignal(n SignalNotifier, c chan<- os.Signal) {
+	n.Notify(c, syscall.SIGHUP)
+}
+
+// notifyShutdownSignal notifies c on receiving Plan 9 shutdown signals using n.
+func notifyShutdownSignal(n SignalNotifier, c chan<- os.Signal) {
+	n.Notify(c, syscall.SIGINT, sigquit)
+}


### PR DESCRIPTION
Information about these signals is taken from https://pkg.go.dev/os/signal and https://9fans.github.io/plan9port/man/man3/notify.html

----

This feels like an [April Fools joke](https://tailscale.com/blog/plan9-port) just several months late, but all that needed to be done to add Plan 9 support was 2 small files, largely copied from the unix versions.
I could not find a better source for Plan 9's signals than the plan9port documentation, so the `quit` syscall might not actually exist.

Feel free to merge this, ignore this, or whatever you like. I was just looking for a way to get https://github.com/ameshkov/dnscrypt working on Plan 9, and patching this library was needed. 😄 